### PR TITLE
Rewrite for Ghost 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple plugin to add Google Cloud Storage support for a Ghost Blog
 
 ## Create storage module
 
-Create index.js file with folder path 'content/storage/gcloud/index.js' (manually create folder if not exist)
+Create this file file with path 'core/server/adapters/storage/gcloud.js' (manually create folder if not exist)
 
     'use strict';
     module.exports = require('ghost-google-cloud-storage');
@@ -35,5 +35,5 @@ Add possibility to change asset domain. Right now it uses the default  `bucket_n
 
 ## Contrinutors
 thombuchi
-
 prenaudin
+gcochard

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "homepage": "https://github.com/thombuchi/ghost-google-cloud-storage",
   "dependencies": {
-    "bluebird": "^3.1.1",
     "@google-cloud/storage": "^1.3.1",
-    "util": "^0.10.3"
+    "bluebird": "^3.1.1",
+    "ghost-storage-base": "0.0.1"
   }
 }


### PR DESCRIPTION
I went through and rewrote the whole thing as necessary, to conform with the undocumented changes for Ghost 1.0. I am using ES2015 classes as that is recommended now.

There's a bug in Ghost that looks for the `content/adapters/storage` outside of the install directory (which is where `node_modules` is) so it cannot find the installed `ghost-google-cloud-storage` module. The workaround is to either put it in the `core/server/adapters` directory, or to npm install `ghost-google-cloud-storage` in the `/var/www/ghost` directory. I chose the latter, as it is a more simple solution.

I can rewrite the readme to tell people to create a `package.json` file with this as the only dependency and then `npm install`, but it seems like overkill to me.