### PR TITLE
Patch: Undefined file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ class GStore extends BaseStore {
         targetFilename;
 
         return new Promise((resolve, reject) => {
-            this.getUniqueFileName(image, targetDir).then(targetFilename => {
+            this.getUniqueFileName(image, targetDir).then(tf => {
+                targetFilename = tf;
                 var opts = {
                     destination: targetDir + targetFilename,
                     metadata: {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,8 @@
+// this package had a bug that made it unusable.
+// forked it and fixed and submitted a PR
+//module.exports = require('ghost-google-cloud-storage');
+// but for now...
+
 'use strict';
 
 var storage     = require('@google-cloud/storage'),
@@ -35,7 +40,7 @@ class GStore extends BaseStore {
             this.getUniqueFileName(image, targetDir).then(tf => {
                 targetFilename = tf;
                 var opts = {
-                    destination: targetDir + targetFilename,
+                    destination: targetFilename,
                     metadata: {
                         cacheControl: `public, max-age=${this.maxAge}`
                     },
@@ -43,7 +48,7 @@ class GStore extends BaseStore {
                 };
                 return this.bucket.upload(image.path, opts);
             }).then(function (data) {
-                return resolve(googleStoragePath + targetDir + targetFilename);
+                return resolve(googleStoragePath + targetFilename);
             }).catch(function (e) {
                 return reject(e);
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost-google-cloud-storage",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A simple plugin to add Google Cloud Storage support for Ghost Blog",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I was getting a weird error where the file would upload to google cloud with the right name, but I'd get `undefined` returned to ghost.

e.g., cloud storage would have `2018/04/myfile.jpg`, but in my post editor it would show as: `2018/04undefined`.

Variable hoisting FTW.